### PR TITLE
Update temp_sensor with the latest version of OpenROAD.(id: 7ff7171)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,7 @@ Please build the following tools:
 
   Yosys <https://github.com/The-OpenROAD-Project/yosys>
 
-  OpenROAD <https://github.com/The-OpenROAD-Project/OpenROAD> (commid id: 8ed8414, with power pins generation enabled)
-
-   - Before building the OpenROAD tools, please enable the `export_opendb_power_pins` function from OpenROAD: uncomment the `export_opendb_power_pins` in `proc opendb_update_grid {}` in OpenROAD/src/pdngen/src/PdnGen.tcl and then rebuild the OpenROAD tool. The flow will terminate with errors if this function is not enabled in OpenROAD.
+  OpenROAD <https://github.com/The-OpenROAD-Project/OpenROAD> (commid id: 7ff7171)
 
   open_pdks <https://github.com/RTimothyEdwards/open_pdks> 
   

--- a/generators/temp-sense-gen/blocks/sky130hd/pdn.cfg
+++ b/generators/temp-sense-gen/blocks/sky130hd/pdn.cfg
@@ -64,7 +64,7 @@ pdngen::specify_grid macro {
     ground_pins "VGND"
     blockages "met1 met2 met3 met4"
     straps {
-        met5 {width 0.93 pitch 40.0 offset 2}
+        met5 {width 1.60 pitch 40.0 offset 2}
     }
     connect {{met4_PIN_ver met5}}
 }

--- a/generators/temp-sense-gen/flow/design/sky130hd/tempsense/config.mk
+++ b/generators/temp-sense-gen/flow/design/sky130hd/tempsense/config.mk
@@ -13,6 +13,8 @@ export SDC_FILE    		= ./design/$(PLATFORM)/$(DESIGN_NICKNAME)/constraint.sdc
 export DIE_AREA   	 	= 0 0 155.48 146.88
 export CORE_AREA   		= 18.4 16.32 137.08 130.56 
 
+export VD1_AREA                 = 33.58 32.64 64.86 62.56
+
 export PDN_CFG 			= ../blocks/$(PLATFORM)/pdn.cfg
 
 export ADDITIONAL_LEFS  	= ../blocks/$(PLATFORM)/lef/HEADER.lef \

--- a/generators/temp-sense-gen/flow/scripts/floorplan.tcl
+++ b/generators/temp-sense-gen/flow/scripts/floorplan.tcl
@@ -55,7 +55,7 @@ if {[info exists ::env(FOOTPRINT)]} {
 } else {
   
   source scripts/read_domain_instances.tcl
-  create_voltage_domain TEMP_ANALOG -area {34 34 65 65}
+  create_voltage_domain TEMP_ANALOG -area {33.58 32.64 64.86 62.56}
 
   initialize_floorplan -die_area $::env(DIE_AREA) \
                        -core_area $::env(CORE_AREA) \

--- a/generators/temp-sense-gen/flow/scripts/io_placement_random.tcl
+++ b/generators/temp-sense-gen/flow/scripts/io_placement_random.tcl
@@ -20,9 +20,9 @@ if {![info exists standalone] || $standalone} {
 }
 
 if {![info exists ::env(FOOTPRINT)]} {
-  io_placer -hor_layer $::env(IO_PLACER_H) \
-            -ver_layer $::env(IO_PLACER_V) \
-            -random
+  place_pins -hor_layer $::env(IO_PLACER_H) \
+             -ver_layer $::env(IO_PLACER_V) \
+             -random
 }
 
 if {![info exists standalone] || $standalone} {


### PR DESCRIPTION
1.change the width of met5 from 0.93 to 1.60 to meet the requirement of layer met5
2.update the location of voltage domain to align cells with the multiple of site width and length
3.replace the obsolete command "io_placer" to “place_pins”