### PR TITLE
Added another way of running generators and a help target in the temp-sense makefile. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,8 +69,8 @@ Please contact mehdi@umich.edu if you have any questions.
 **Another way to run the generators is using the efabless docker image which is currently used to test the temp-sense generator flow during smoke test**
 
 ***:information_source: - Install docker on your machine based on the operating system before you proceed***
- 
-1. Set PDK_ROOT variable to the location of your PDK data location which contains sky130A directory. 
+
+1. Set PDK_ROOT variable to the location of your PDK data location which contains sky130A directory.
    eg: `export PDK_ROOT=/home/user1/pdks`
 
 2. Now clone the OpenFASOC repository - `git clone https://github.com/idea-fasoc/OpenFASOC.git`

--- a/README.md
+++ b/README.md
@@ -66,15 +66,34 @@ make sky130hd_temp
 
 Please contact mehdi@umich.edu if you have any questions.
 
+**Another way to run the generators is using the efabless docker image which is currently used to test the temp-sense generator flow during smoke test**
 
-#Generators
+***:information_source: - Install docker on your machine based on the operating system before you proceed***
+ 
+1. Set PDK_ROOT variable to the location of your PDK data location which contains sky130A directory. 
+   eg: `export PDK_ROOT=/home/user1/pdks`
+
+2. Now clone the OpenFASOC repository - `git clone https://github.com/idea-fasoc/OpenFASOC.git`
+
+3. Move to the OpenFASOC directory - `cd OpenFASOC`
+
+4. Now run this command - `docker run --rm -v /github/OpenLane:/OpenLane -v $PDK_ROOT:$PDK_ROOT -e PDK_ROOT=$PDK_ROOT -v $PWD:$PWD -w $PWD efabless/openlane:2021.12.22_01.51.18 bash -c "yum install -y time && cd ./openfasoc/generators/temp-sense-gen && make sky130hd_temp`
+
+***:warning: Files will be generated with root privileges. So, while cleaning the run, use `sudo` to have a complete clean.***
+## Generators
 
 **[temp-sense-gen:-](https://github.com/idea-fasoc/OpenFASOC/tree/main/openfasoc/generators/dcdc-gen)** A fully automated SoC generator that uses an all-digital temperature sensor architecture, that relies on a new subthreshold oscillator (achieved using the auxiliary cell “Header Cell“) for realizing synthesizable thermal sensors.
+
 **[cryo-gen:-](https://github.com/idea-fasoc/OpenFASOC/tree/main/openfasoc/generators/cryo-gen)**
+
 **[dcdc-gen:-](https://github.com/idea-fasoc/OpenFASOC/tree/main/openfasoc/generators/dcdc-gen)**
+
 **[gdsfactory:-](https://github.com/idea-fasoc/OpenFASOC/tree/main/openfasoc/generators/dcdc-gen)**
+
 **[lc-dco:-](https://github.com/idea-fasoc/OpenFASOC/tree/main/openfasoc/generators/dcdc-gen)**
+
 **[ido-gen:-](https://github.com/idea-fasoc/OpenFASOC/tree/main/openfasoc/generators/dcdc-gen)**
+
 **[scpa-gen:-](https://github.com/idea-fasoc/OpenFASOC/tree/main/openfasoc/generators/dcdc-gen)**
 
 # Spice Simulation Flow

--- a/openfasoc/generators/temp-sense-gen/.gitignore
+++ b/openfasoc/generators/temp-sense-gen/.gitignore
@@ -1,3 +1,5 @@
 __pycache__/
 work/
 *.log
+core.*
+*.swp

--- a/openfasoc/generators/temp-sense-gen/Makefile
+++ b/openfasoc/generators/temp-sense-gen/Makefile
@@ -3,9 +3,9 @@
 # ==============================================================================
 
 help:banner
-	@@echo "OpenFASOC is focused on developing a complete system-on-chip (SoC) synthesis tool"
+	@@echo "OpenFASOC is focused on open-source automate analog generation"
 	@@echo "from user specification to GDSII with fully open-sourced tools."
-	@@echo "This project is led by a team of researchers at the Universities of Michigan, Virginia, and Arm"
+	@@echo "This project is led by a team of researchers at the Universities of Michigan is inspired from FASOC whcih sits on proprietary tools"
 	@@echo "For more info, visit https://fasoc.engin.umich.edu/"
 	@@echo  ""
 	@@echo "IP: Temperature Sensor \nSupported Technology: Sky130A \nSupported Library: sky130hd"

--- a/openfasoc/generators/temp-sense-gen/Makefile
+++ b/openfasoc/generators/temp-sense-gen/Makefile
@@ -17,7 +17,7 @@ help:banner
 	@@echo "    >> This will create the verilog file for the thermal sensor IP. It doesn't create a macro, won't create lef/def/gds files and won't run simulations "
 	@@echo "3. make sky130hd_temp_full"
 	@@echo "    >> This will create the macro for the thermal sensor, creates the lef/def/gds files, performs lvs/drc checks and also runs simulations."
-	@@echo "    >> [Warning] Currently, this target is in alpha phase" 
+	@@echo "    >> [Warning] Currently, this target is in alpha phase"
 	@@echo "4. make clean"
 	@@echo "    >> This will clean all files generated during the run inside the run/, flow/ and work/ directories"
 	@@echo "5. make help"
@@ -50,4 +50,3 @@ banner:
 	@@echo "  \___/|_|    |_____|_| \_|_| /_/   \_\|____/ \___/ \____|"
 	@@echo ""
 	@@echo "==============================================================="
-

--- a/openfasoc/generators/temp-sense-gen/Makefile
+++ b/openfasoc/generators/temp-sense-gen/Makefile
@@ -2,6 +2,27 @@
 # Run temp sensor design
 # ==============================================================================
 
+help:banner
+	@@echo "OpenFASOC is focused on developing a complete system-on-chip (SoC) synthesis tool"
+	@@echo "from user specification to GDSII with fully open-sourced tools."
+	@@echo "This project is led by a team of researchers at the Universities of Michigan, Virginia, and Arm"
+	@@echo "For more info, visit https://fasoc.engin.umich.edu/"
+	@@echo  ""
+	@@echo "IP: Temperature Sensor \nSupported Technology: Sky130A \nSupported Library: sky130hd"
+	@@echo ""
+	@@echo "Targets supported:"
+	@@echo "1. make sky130hd_temp"
+	@@echo "    >> This will create the macro for the thermal sensor, creates the lef/def/gds files and performs lvs/drc checks. It won't run simulations."
+	@@echo "2. make sky130hd_temp_verilog"
+	@@echo "    >> This will create the verilog file for the thermal sensor IP. It doesn't create a macro, won't create lef/def/gds files and won't run simulations "
+	@@echo "3. make sky130hd_temp_full"
+	@@echo "    >> This will create the macro for the thermal sensor, creates the lef/def/gds files, performs lvs/drc checks and also runs simulations."
+	@@echo "    >> [Warning] Currently, this target is in alpha phase" 
+	@@echo "4. make clean"
+	@@echo "    >> This will clean all files generated during the run inside the run/, flow/ and work/ directories"
+	@@echo "5. make help"
+	@@echo "    >> Displays this message"
+
 sky130hd_temp_verilog:
 	python3 tools/temp-sense-gen.py --specfile test.json --outputDir ./work --platform sky130hd --mode verilog
 
@@ -19,3 +40,14 @@ clean:
 	rm -rf tools/*.pyc tools/__pycache__/
 	cd flow && make clean_all
 	cd simulations && rm -rf run
+
+banner:
+	@@echo "=============================================================="
+	@@echo "   ___  _____ ______ _   _ _____  _     ____   ___   ____"
+	@@echo "  / _ \|  _  \| ____| \ | |  ___|/ \   / ___| / _ \ / ___|"
+	@@echo " | | | | |_) ||  _| |  \| | |_  / _ \  \___ \| | | | |    "
+	@@echo " | |_| |  __/ | |___| |\  |  _|/ ___ \  ___) | |_| | |___ "
+	@@echo "  \___/|_|    |_____|_| \_|_| /_/   \_\|____/ \___/ \____|"
+	@@echo ""
+	@@echo "==============================================================="
+


### PR DESCRIPTION
@msaligane I added an other way of running the generators (using the docker image). I also added a new target "help" in the temp-sense generator Makefile. Just by typing `make`, it will produce below info. We can extend this to all other generators once they are ready.
 
![image](https://user-images.githubusercontent.com/100982953/170697816-661ed630-9a1b-4a67-95cb-6ca9860eb5f3.png)
