### PR TITLE
Removed saicharan0112/OpenFASOC:openfasoc_ci branch dependency for CI

### DIFF
--- a/.github/workflows/temp_sense_sky130hd.yml
+++ b/.github/workflows/temp_sense_sky130hd.yml
@@ -14,17 +14,9 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v2
 
-      - name: Use PDK data from openfasoc_ci branch
-        run: |
-          mkdir -p /home/runner/testing && cd /home/runner/testing
-          git clone https://github.com/saicharan0112/OpenFASOC.git
-          cd OpenFASOC
-          git checkout openfasoc_ci
-
       - name: Make Sky130HD Temp
         env:
-          PDK_ROOT: /home/runner/testing/OpenFASOC/pdk_test
-          IMAGE_NAME: efabless/openlane:2021.12.22_01.51.18
+                IMAGE_NAME: saicharan0112/openfasoc:stable
         run: |
           cd $GITHUB_WORKSPACE
           touch file.log
@@ -36,7 +28,7 @@ jobs:
             -w $PWD\
             $IMAGE_NAME\
             bash -c "\
-              yum install -y time &&\
+              export PDK_ROOT=/pdk_data/ &&\
               cd ./openfasoc/generators/temp-sense-gen &&\
               make sky130hd_temp\
             ">> file.log

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Please contact mehdi@umich.edu if you have any questions.
 
 3. Change to the OpenFASOC directory - `cd OpenFASOC`
 
-4. Run this command to access OpenFASOC folder from the container - `docker run -it -v $PWD:$PWD saicharan0112/openfasoc:stable`
+4. Run this command to access OpenFASOC folder from the container - `docker run -it -v $PWD:$PWD -e $PDK_ROOT:/pdk_data/ saicharan0112/openfasoc:stable`
 
 5. To test, go to `openfasoc/generators/temp-sense` and type `make sky130hd_temp` to run the temp-sense generator.
 

--- a/README.md
+++ b/README.md
@@ -95,16 +95,13 @@ Please contact mehdi@umich.edu if you have any questions.
 
 ***:information_source:  Install docker and PDK using open_pdks on your machine before you proceed***
 
-1. Set PDK_ROOT variable to the location of your PDK data location which contains sky130A directory.
-   eg: `export PDK_ROOT=/home/user1/pdks`
+1. Clone the OpenFASOC repository - `git clone https://github.com/idea-fasoc/OpenFASOC.git`
 
-2. Now clone the OpenFASOC repository - `git clone https://github.com/idea-fasoc/OpenFASOC.git`
+2. Change to the OpenFASOC directory - `cd OpenFASOC`
 
-3. Change to the OpenFASOC directory - `cd OpenFASOC`
+3. Run this command to access OpenFASOC folder from the container - `docker run -it -v $PWD:$PWD -e $PDK_ROOT:/pdk_data/ saicharan0112/openfasoc:stable`
 
-4. Run this command to access OpenFASOC folder from the container - `docker run -it -v $PWD:$PWD -e $PDK_ROOT:/pdk_data/ saicharan0112/openfasoc:stable`
-
-5. To test, go to `openfasoc/generators/temp-sense` and type `make sky130hd_temp` to run the temp-sense generator.
+4. To test, go to `openfasoc/generators/temp-sense` and type `make sky130hd_temp` to run the temp-sense generator.
 
 ***:warning:  Files will be generated with root privileges. So, while cleaning the run, use `sudo` to have a complete clean.***
 

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Please contact mehdi@umich.edu if you have any questions.
 
 **Another way to run the generators is using the efabless docker image which is currently used to test the temp-sense generator flow during smoke test**
 
-***:information_source:  Install docker and PDK using open_pdks on your machine before you proceed***
+***:information_source:  Install docker on your machine before you proceed***
 
 1. Clone the OpenFASOC repository - `git clone https://github.com/idea-fasoc/OpenFASOC.git`
 

--- a/README.md
+++ b/README.md
@@ -102,7 +102,9 @@ Please contact mehdi@umich.edu if you have any questions.
 
 3. Change to the OpenFASOC directory - `cd OpenFASOC`
 
-4. Now run this command just to run temp-sense generator - `docker run --rm -v /github/OpenLane:/OpenLane -v $PDK_ROOT:$PDK_ROOT -e PDK_ROOT=$PDK_ROOT -v $PWD:$PWD -w $PWD saicharan0112/openfasoc:ci bash -c "yum install -y time && cd ./openfasoc/generators/temp-sense-gen && make sky130hd_temp`
+4. Run this command to access OpenFASOC folder from the container - `docker run -it -v $PWD:$PWD saicharan0112/openfasoc:stable`
+
+5. To test, go to `openfasoc/generators/temp-sense` and type `make sky130hd_temp` to run the temp-sense generator.
 
 ***:warning:  Files will be generated with root privileges. So, while cleaning the run, use `sudo` to have a complete clean.***
 

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Please contact mehdi@umich.edu if you have any questions.
 
 **Another way to run the generators is using the efabless docker image which is currently used to test the temp-sense generator flow during smoke test**
 
-***:information_source:  Install docker on your machine based on the operating system before you proceed***
+***:information_source:  Install docker and PDK using open_pdks on your machine before you proceed***
 
 1. Set PDK_ROOT variable to the location of your PDK data location which contains sky130A directory.
    eg: `export PDK_ROOT=/home/user1/pdks`

--- a/README.md
+++ b/README.md
@@ -100,9 +100,9 @@ Please contact mehdi@umich.edu if you have any questions.
 
 2. Now clone the OpenFASOC repository - `git clone https://github.com/idea-fasoc/OpenFASOC.git`
 
-3. Move to the OpenFASOC directory - `cd OpenFASOC`
+3. Change to the OpenFASOC directory - `cd OpenFASOC`
 
-4. Now run this command - `docker run --rm -v /github/OpenLane:/OpenLane -v $PDK_ROOT:$PDK_ROOT -e PDK_ROOT=$PDK_ROOT -v $PWD:$PWD -w $PWD efabless/openlane:2021.12.22_01.51.18 bash -c "yum install -y time && cd ./openfasoc/generators/temp-sense-gen && make sky130hd_temp`
+4. Now run this command just to run temp-sense generator - `docker run --rm -v /github/OpenLane:/OpenLane -v $PDK_ROOT:$PDK_ROOT -e PDK_ROOT=$PDK_ROOT -v $PWD:$PWD -w $PWD saicharan0112/openfasoc:ci bash -c "yum install -y time && cd ./openfasoc/generators/temp-sense-gen && make sky130hd_temp`
 
 ***:warning:  Files will be generated with root privileges. So, while cleaning the run, use `sudo` to have a complete clean.***
 


### PR DESCRIPTION
I removed my openfasoc_ci branch dependency for smoke testing. Now the testing happens with a new image which was created above efabless/openlane:2021.12.22_01.51.18 along with the addition of pdk data (which was built somewhere around Nov 2021). 
This is still a temporary solution until we find stable commit numbers of all tools for OpenFASOC to run.