### PR TITLE
Change Docker image run options

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Please contact mehdi@umich.edu if you have any questions.
 
 2. Change to the OpenFASOC directory - `cd OpenFASOC`
 
-3. Run this command to access OpenFASOC folder from the container - `docker run -it -v $PWD:$PWD -e $PDK_ROOT:/pdk_data/ saicharan0112/openfasoc:stable`
+3. Run this command to access OpenFASOC folder from the container - `docker run -it -v $PWD:$PWD -e PDK_ROOT='/pdk_data' -w $PWD saicharan0112/openfasoc:stable`
 
 4. To test, go to `openfasoc/generators/temp-sense` and type `make sky130hd_temp` to run the temp-sense generator.
 


### PR DESCRIPTION
The (current) appropriate format for passing an env variable is using an equal sign. With the previous command, in the latest Docker version (20.10.17), the PDK_ROOT variable wouldn't load

 Also adds the -w option to set the working directory at /OpenFASOC once the container loads, for simpler use