### PR TITLE
HEADER cells are placed in an organized fashion

### DIFF
--- a/openfasoc/generators/temp-sense-gen/tools/parse_rpt.py
+++ b/openfasoc/generators/temp-sense-gen/tools/parse_rpt.py
@@ -12,12 +12,14 @@ else:
 # LVS Bypassed
 
 lvs_filename = "flow/reports/sky130hd/tempsense/6_final_lvs.rpt"
-lvs_line = subprocess.check_output(['tail', '-1', lvs_filename]).decode(sys.stdout.encoding)
+lvs_line = subprocess.check_output(["tail", "-1", lvs_filename]).decode(
+    sys.stdout.encoding
+)
 
 regex = r"Netlists do not match"
 match = re.search(regex, lvs_line)
 
 if match != None:
-	raise ValueError("LVS failed!")
+    raise ValueError("LVS failed!")
 else:
-	print("LVS is clean!")
+    print("LVS is clean!")

--- a/openfasoc/generators/temp-sense-gen/tools/readparamgen.py
+++ b/openfasoc/generators/temp-sense-gen/tools/readparamgen.py
@@ -647,11 +647,9 @@ def main():
             if Optimization == "power":
                 # THIS IS THE MAIN FUNCTION for power optimization
                 print("*********Performing Power Optimization*********")
-                time.sleep(5)
                 return calculate_min_error_new(df, delta_1st_pass, number_rows)
             elif Optimization == "error":
                 print("*********Performing Error Optimization*********")
-                time.sleep(5)
                 # THIS IS THE MAIN FUNCTION for error optimization
                 return calculate_min_power_new(df, delta_1st_pass, number_rows)
 

--- a/openfasoc/generators/temp-sense-gen/tools/temp-sense-gen.py
+++ b/openfasoc/generators/temp-sense-gen/tools/temp-sense-gen.py
@@ -179,8 +179,6 @@ print("#----------------------------------------------------------------------")
 print("# Place and Route finished")
 print("#----------------------------------------------------------------------")
 
-time.sleep(2)
-
 p = sp.Popen(["make", "magic_drc"], cwd=flowDir)
 p.wait()
 if p.returncode:
@@ -190,8 +188,6 @@ if p.returncode:
 print("#----------------------------------------------------------------------")
 print("# DRC finished")
 print("#----------------------------------------------------------------------")
-
-time.sleep(2)
 
 p = sp.Popen(["make", "netgen_lvs"], cwd=flowDir)
 p.wait()
@@ -246,8 +242,6 @@ shutil.copyfile(
     genDir + args.outputDir + "/6_final_lvs.rpt",
 )
 
-
-time.sleep(2)
 
 print("#----------------------------------------------------------------------")
 print("# Macro Generated")


### PR DESCRIPTION
I wrote a tcl proc in the detailed place tcl script which loops through all cells with a specific name and place them semi-stacked on top of each other based off a row option given. The parameters I gave to this proc to place the HEADER cells is "10" and "HEADER".
I also removed useless pauses in the script. There were several time.sleep() which seem to serve no purpose and add 11 seconds to each complete run of tempsense gen.
Let me know if I need to make any changes. The changes I made in this PR were tested using Obed's fork.