### PR TITLE
Fix failing docs build

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,5 @@
 	url = https://github.com/efabless/caravel_user_project.git
 [submodule "tapeouts"]
 	path = tapeouts
-	url = git@github.com:idea-fasoc/openfasoc-tapeouts.git
+	url = https://github.com/idea-fasoc/openfasoc-tapeouts.git
+	branch = main

--- a/docs/source/tapeouts.rst
+++ b/docs/source/tapeouts.rst
@@ -3,5 +3,19 @@ Tapeouts
 
 This page contains documentation on tapeouts of circuits generated with OpenFASoC, along with auxiliary files and experimental results. Source is uploaded in the `openfasoc-tapeouts <https://github.com/idea-fasoc/openfasoc-tapeouts>`_ repository.
 
+The tapeouts repository is included as a git submodule in OpenFASoC. To download it, run this command after having cloned OpenFASoC:
+
+.. code-block::
+
+  git submodule update --init tapeouts
+
+Files will be downloaded to the `tapeouts/` folder. In case they are not updated with the latest additions in openfasoc-tapeouts, run:
+
+.. code-block::
+
+  git submodule update --remote tapeouts
+
+This will pull the latest commits to the submodule.
+
 .. include:: ../../tapeouts/README.rst
   :start-after: .. openfasoc_docs


### PR DESCRIPTION
The docs build was failing because I accidentally added the submodule in .gitmodules with an ssh link, not supported by Read the Docs. It should be working now.