### PR TITLE
add back ndr rules for VIN route

### DIFF
--- a/openfasoc/generators/temp-sense-gen/flow/scripts/openfasoc/add_ndr_rules.tcl
+++ b/openfasoc/generators/temp-sense-gen/flow/scripts/openfasoc/add_ndr_rules.tcl
@@ -1,0 +1,11 @@
+set block [ord::get_db_block]
+
+# Add 2W, 2S rule to ring oscillator input
+create_ndr -name NDR_5W_5S \
+           -spacing { *5 } \
+           -width { *5 }
+
+set ndr [$block findNonDefaultRule NDR_5W_5S]
+$ndr setHardSpacing 1
+
+assign_ndr -ndr NDR_5W_5S -net r_VIN

--- a/openfasoc/generators/temp-sense-gen/flow/scripts/openfasoc/pre_global_route.tcl
+++ b/openfasoc/generators/temp-sense-gen/flow/scripts/openfasoc/pre_global_route.tcl
@@ -2,6 +2,9 @@
 source $::env(SCRIPTS_DIR)/openfasoc/create_routable_power_net.tcl
 create_routable_power_net "VIN" $::env(VIN_ROUTE_CONNECTION_POINTS)
 
+# NDR rules
+source $::env(SCRIPTS_DIR)/openfasoc/add_ndr_rules.tcl
+
 # Custom connections
 source $::env(SCRIPTS_DIR)/openfasoc/create_custom_connections.tcl
 if {[info exist ::env(CUSTOM_CONNECTION)]} {


### PR DESCRIPTION
Does a simple add back of the script that created the NDR rules for the r_VIN pin. comment out the line which sources this script in flow/scripts/openfasoc/pre_globalroute.tcl to prevent the NDR from being added.