### PR TITLE
LDO: Fixed latch placement to fix LVS issues and Fixed DRC violations (including vref block)

### DIFF
--- a/openfasoc/common/drc-lvs-check/magic_commands.tcl
+++ b/openfasoc/common/drc-lvs-check/magic_commands.tcl
@@ -8,6 +8,13 @@
 #   tech load $::env(TECH)
 # }
 
+# gds flatglob commands removes the drc errors caused by hierarchy that magic can't process.
+# gds faltglob *capacitor_test_nf* is specific to ldo-gen
+gds flatglob *$$*
+gds flatglob *VIA*
+gds flatglob *CDNS*
+gds flatglob *capacitor_test_nf*
+
 gds read $::env(RESULTS_DIR)/6_final.gds
 proc custom_drc_save_report {{cellname ""} {outfile ""}} {
 

--- a/openfasoc/generators/ldo-gen/flow/scripts/detail_place.tcl
+++ b/openfasoc/generators/ldo-gen/flow/scripts/detail_place.tcl
@@ -8,6 +8,9 @@ set_placement_padding -global \
     -left $::env(CELL_PAD_IN_SITES_DETAIL_PLACEMENT) \
     -right $::env(CELL_PAD_IN_SITES_DETAIL_PLACEMENT)
 
+# Place cmp1 correctly
+source $::env(SCRIPTS_DIR)/openfasoc/custom_place.tcl
+
 detailed_placement
 
 if {[info exists ::env(ENABLE_DPO)] && $::env(ENABLE_DPO)} {

--- a/openfasoc/generators/ldo-gen/flow/scripts/openfasoc/custom_place.tcl
+++ b/openfasoc/generators/ldo-gen/flow/scripts/openfasoc/custom_place.tcl
@@ -1,0 +1,6 @@
+# This will place the comparator latch (cmp1) correctly which will not cause LVS issues further in the flow. This is used before detail_placement.
+set block [ord::get_db_block]
+set inst [$block findInst cmp1]
+set instName [$inst getName]
+
+place_cell -inst_name $instName -orient MY -origin [list 170 40.700] -status PLACED

--- a/openfasoc/generators/ldo-gen/flow/scripts/openfasoc/custom_place.tcl
+++ b/openfasoc/generators/ldo-gen/flow/scripts/openfasoc/custom_place.tcl
@@ -3,4 +3,4 @@ set block [ord::get_db_block]
 set inst [$block findInst cmp1]
 set instName [$inst getName]
 
-place_cell -inst_name $instName -orient MY -origin [list 170 40.700] -status PLACED
+place_cell -inst_name $instName -orient MY -origin [list 151.680 40.700] -status FIRM


### PR DESCRIPTION
The updated lef version of comparator latch (cmp1) was causing LVS issues due to incorrect placement for some configurations.
@alibillalhammoud Also faced the same issue with the older version of cmp1 where in the number of switches in design were low. 
This PR is workaround for this issue. The cmp1 will be placed correctly so that it will not cause LVS issue. 