### PR TITLE
Modified report parser script to catch lvs failing messages

### DIFF
--- a/dependencies.sh
+++ b/dependencies.sh
@@ -110,7 +110,7 @@ elif cat /etc/os-release | grep -e "centos" >> /dev/null
 then
 	yum group install "Development Tools" -y
 	yum install qtbase5-dev qttools5-dev libqt5xmlpatterns5-dev qtmultimedia5-dev libqt5multimediawidgets5 libqt5svg5-dev ruby ruby-dev python3-dev libz-dev qt-x11 -y
-	wget https://www.klayout.org/downloads/CentOS_7/klayout-0.27.10-0.x86_64.rpm
+	wget https://www.klayout.org/downloads/CentOS_7/klayout-0.28.2-0.x86_64.rpm
 	rpm -i klayout-0.27.10-0.x86_64.rpm
 	yum install time -y
 elif cat /etc/os-release | grep -e "el7" -e "el8" >> /dev/null

--- a/openfasoc/common/platform_config.json
+++ b/openfasoc/common/platform_config.json
@@ -1,5 +1,5 @@
 {
-  "simTool": "xyce",
+  "simTool": "ngspice",
   "simMode": "partial",
   "open_pdks_GCP": "/shared/OpenLane/pdks/sky130A",
   "open_pdks_GHA": "/home/runner/work/sky130A",

--- a/openfasoc/generators/temp-sense-gen/tools/parse_rpt.py
+++ b/openfasoc/generators/temp-sense-gen/tools/parse_rpt.py
@@ -1,4 +1,3 @@
-import subprocess, sys, re
 
 drc_filename = "flow/reports/sky130hd/tempsense/6_final_drc.rpt"
 num_lines = sum(1 for line in open(drc_filename))
@@ -9,17 +8,13 @@ else:
     print("DRC is clean!")
 
 
-# LVS Bypassed
-
 lvs_filename = "flow/reports/sky130hd/tempsense/6_final_lvs.rpt"
-lvs_line = subprocess.check_output(["tail", "-1", lvs_filename]).decode(
-    sys.stdout.encoding
-)
 
-regex = r"Netlists do not match"
-match = re.search(regex, lvs_line)
+with open(lvs_filename) as f:
+    f1=f.read()
 
-if match != None:
-    raise ValueError("LVS failed!")
-else:
-    print("LVS is clean!")
+    if "failed" in f1:
+        print("LVS failed!")
+    else:
+        print("LVS is clean!")
+

--- a/openfasoc/generators/temp-sense-gen/tools/parse_rpt.py
+++ b/openfasoc/generators/temp-sense-gen/tools/parse_rpt.py
@@ -1,4 +1,3 @@
-
 drc_filename = "flow/reports/sky130hd/tempsense/6_final_drc.rpt"
 num_lines = sum(1 for line in open(drc_filename))
 
@@ -11,10 +10,9 @@ else:
 lvs_filename = "flow/reports/sky130hd/tempsense/6_final_lvs.rpt"
 
 with open(lvs_filename) as f:
-    f1=f.read()
+    f1 = f.read()
 
     if "failed" in f1:
         print("LVS failed!")
     else:
         print("LVS is clean!")
-


### PR DESCRIPTION
As described in #114, Netgen doesn't exit with error code 1 when the top level netlist fails. The current report parser uses specific sentence to detect whether LVS is passing or not. 
This PR fixes this problem and also updates the Klayout version to 0.28.x in the dependencies.sh script.