### PR TITLE
Fix shebang on dependencies.sh

### DIFF
--- a/dependencies.sh
+++ b/dependencies.sh
@@ -1,4 +1,4 @@
-#/bin/bash
+#!/bin/bash
 
 ma_ver=$(python -c"import sys; print(str(sys.version_info.major))")
 mi_ver=$(python -c"import sys; print(str(sys.version_info.minor))")


### PR DESCRIPTION
Fix shebang string. When execute with `./dependencies.sh`, it will always run by using `/bin/bash` when the default shell is different from `bash`.