### PR TITLE
[Issue]: Update dependencies.sh script

### DIFF
--- a/dependencies.mk
+++ b/dependencies.mk
@@ -1,0 +1,28 @@
+# Makefile for installing and updating dependencies
+
+DEPENDENCIES_SCRIPT = dependencies.sh
+
+# Phony targets
+.PHONY: install update #clean clean_install clean_update
+
+# Default target
+all: install update
+
+# Target for installing dependencies
+install:
+	echo "y" | ./$(DEPENDENCIES_SCRIPT)
+
+# Target for updating dependencies
+update:
+	echo "u" | ./$(DEPENDENCIES_SCRIPT)
+
+# # Target for cleaning up generated files
+# clean:
+# 	# Command to clean up generated files goes here, but 
+# 	# currently this makefile does not generate new files in the first place
+
+# # Target for cleaning up and reinstalling dependencies
+# clean_install: clean install
+
+# # Target for cleaning up and updating dependencies
+# clean_update: clean update

--- a/dependencies.sh
+++ b/dependencies.sh
@@ -38,16 +38,33 @@ if $update_confirmed; then
                 echo "Conda could not be found. If you have not yet successfully installed the dependencies, you cannot update the dependencies."
                 exit
         fi
-        echo "Note: Because the latest version of Conda requires Python 3.8 or higher, your device
+        printf "\nNote: Because the latest version of Conda requires Python 3.8 or higher, your device
 must be equipped with Python 3.8 or above for this script to fully update everything. If you have
-Python 3.7, this script will nonetheless run and attempt to install every compatible update."
+Python 3.7, this script will nonetheless run and attempt to install every compatible update. \n"
         export PATH=/usr/bin/miniconda3/bin:$PATH
+
+        printf "\nAttempting to update Conda using: conda update conda -y \n\n"
         conda update conda -y
-        if [ $? != 0 ]; then conda install -c anaconda conda -y; if [ $? != 0 ]; then echo "Failed to update conda" ; exit ; fi ; fi
+        if [ $? == 0 ]
+        then
+        printf "\n\nConda updated successfully with: conda update conda -y."
+        else 
+        printf "\n\nFailed to update Conda using: conda update conda -y."
+        printf "Attempting instead to update Conda using: install -c anaconda conda -y"
+        conda install -c anaconda conda -y; if [ $? == 0 ]; then 
+        printf "\n\nConda updated successfully with: install -c anaconda conda -y"
+        else
+        printf "\n\nConda could not be updated."; fi
+        fi
+
         update_successful=true
+        printf "\n\nAttempting to update packages using: conda update --all -y \n"
         conda update --all -y
-        if [ $? != 0 ]; then 
-        echo "Attempting to install core packages individually..."
+        if [ $? == 0 ]; then 
+        printf "Packages updated successfully with: conda update --all -y"
+        else 
+        printf "\n\nFailed to update packages using: conda update --all -y."
+        printf "Attempting instead to install core packages individually..."
         conda install -c litex-hub magic -y; if [ $? != 0 ]; then update_successful=false; echo "magic could not be updated"; fi
         conda install -c litex-hub netgen -y; if [ $? != 0 ]; then update_successful=false; echo "netgen could not be updated"; fi
         conda install -c litex-hub open_pdks.sky130a -y; if [ $? != 0 ]; then update_successful=false; echo "open_pdks could not be updated"; fi
@@ -95,10 +112,9 @@ Python 3.7, this script will nonetheless run and attempt to install every compat
         # echo "nspice was successfully updated."
         # fi
         if [ $update_successful ]; then
-        echo "Magic, netgen, open_pdks, openroad, and yosys updated successfully to latest versions possible given user's Python (completely latest versions if >=3.8)."
+        printf "\n\nMagic, netgen, open_pdks, openroad, and yosys updated successfully to latest releases possible given user's Python version (most recent releases if version >=3.8).\n"
         fi
-        echo "To update Klayout, visit https://www.klayout.de/build.html and follow the instructions."
-
+        exit
 fi
 
 

--- a/dependencies.sh
+++ b/dependencies.sh
@@ -54,15 +54,14 @@ Python 3.7, this script will nonetheless run and attempt to install every compat
         conda install -c litex-hub openroad -y; if [ $? != 0 ]; then update_successful=false; echo "openroad could not be updated"; fi
         conda install -c litex-hub yosys -y; if [ $? != 0 ]; then update_successful=false; echo "yosys could not be updated"; fi
         fi
-        if [ $update_successful ]; then
-        echo "Magic, netgen, open_pdks, openroad, and yosys updated successfully to latest versions possible given user's Python (completely latest versions if >=3.8)."
-        fi
 
+        ngspice_updated=false
         echo "Updating ngspice..."
         cd ngspice
         git pull --rebase
         ./compile_linux.sh 
         if [ $? == 0 ]; then
+        ngspice_updated=true
         echo "ngspice updated successfully."
         else 
         echo "nspice could not be updated."
@@ -91,7 +90,13 @@ Python 3.7, this script will nonetheless run and attempt to install every compat
         echo "xyce could not be updated."
         fi
 
-        echo "All dependencies except Klayout have been updated. To update Klayout, visit https://www.klayout.de/build.html and follow the instructions."
+        if [ $ngspice_updated ]; then
+        echo "nspice was successfully updated."
+        fi
+        if [ $update_successful ]; then
+        echo "Magic, netgen, open_pdks, openroad, and yosys updated successfully to latest versions possible given user's Python (completely latest versions if >=3.8)."
+        fi
+        echo "To update Klayout, visit https://www.klayout.de/build.html and follow the instructions."
 
 fi
 

--- a/dependencies.sh
+++ b/dependencies.sh
@@ -55,44 +55,44 @@ Python 3.7, this script will nonetheless run and attempt to install every compat
         conda install -c litex-hub yosys -y; if [ $? != 0 ]; then update_successful=false; echo "yosys could not be updated"; fi
         fi
 
-        ngspice_updated=false
-        echo "Updating ngspice..."
-        cd ngspice
-        git pull --rebase
-        ./compile_linux.sh 
-        if [ $? == 0 ]; then
-        ngspice_updated=true
-        echo "ngspice updated successfully."
-        else 
-        echo "nspice could not be updated."
-        fi
+        # ngspice_updated=false
+        # echo "Updating ngspice..."
+        # cd ngspice
+        # git pull --rebase
+        # ./compile_linux.sh 
+        # if [ $? == 0 ]; then
+        # ngspice_updated=true
+        # echo "ngspice updated successfully."
+        # else 
+        # echo "nspice could not be updated."
+        # fi
 
-        echo "Updating xyce..."
-        SRCDIR=$PWD/Trilinos-trilinos-release-12-12-1
-        LIBDIR=/opt/xyce/xyce_lib
-        INSTALLDIR=/opt/xyce/xyce_serial
-        FLAGS="-O3 -fPIC"
-        if cat /etc/os-release | grep "centos" >> /dev/null
-        then
-                yum install -y centos-release-scl
-                yum install -y devtoolset-7
-                scl enable devtoolset-7 bash
-        fi
-        cd ./docker/conda/scripts/Xyce
-        git pull --rebase
-        ./bootstrap
-        ./configure CXXFLAGS="-O3 -std=c++11" ARCHDIR=$LIBDIR --prefix=$INSTALLDIR CPPFLAGS="-I/usr/include/suitesparse"
-        make
-        make install
-                if [ $? == 0 ]; then
-        echo "xyce updated successfully."
-        else 
-        echo "xyce could not be updated."
-        fi
+        # echo "Updating xyce..."
+        # SRCDIR=$PWD/Trilinos-trilinos-release-12-12-1
+        # LIBDIR=/opt/xyce/xyce_lib
+        # INSTALLDIR=/opt/xyce/xyce_serial
+        # FLAGS="-O3 -fPIC"
+        # if cat /etc/os-release | grep "centos" >> /dev/null
+        # then
+        #         yum install -y centos-release-scl
+        #         yum install -y devtoolset-7
+        #         scl enable devtoolset-7 bash
+        # fi
+        # cd ./docker/conda/scripts/Xyce
+        # git pull --rebase
+        # ./bootstrap
+        # ./configure CXXFLAGS="-O3 -std=c++11" ARCHDIR=$LIBDIR --prefix=$INSTALLDIR CPPFLAGS="-I/usr/include/suitesparse"
+        # make
+        # make install
+        #         if [ $? == 0 ]; then
+        # echo "xyce updated successfully."
+        # else 
+        # echo "xyce could not be updated."
+        # fi
 
-        if [ $ngspice_updated ]; then
-        echo "nspice was successfully updated."
-        fi
+        # if [ $ngspice_updated ]; then
+        # echo "nspice was successfully updated."
+        # fi
         if [ $update_successful ]; then
         echo "Magic, netgen, open_pdks, openroad, and yosys updated successfully to latest versions possible given user's Python (completely latest versions if >=3.8)."
         fi

--- a/dependencies.sh
+++ b/dependencies.sh
@@ -58,7 +58,7 @@ Python 3.7, this script will nonetheless run and attempt to install every compat
         # ngspice_updated=false
         # echo "Updating ngspice..."
         # cd ngspice
-        # git pull --rebase
+        # git pull
         # ./compile_linux.sh 
         # if [ $? == 0 ]; then
         # ngspice_updated=true
@@ -66,7 +66,9 @@ Python 3.7, this script will nonetheless run and attempt to install every compat
         # else 
         # echo "nspice could not be updated."
         # fi
-
+        # cd ..
+        
+        # cd ./docker/conda/scripts/Xyce
         # echo "Updating xyce..."
         # SRCDIR=$PWD/Trilinos-trilinos-release-12-12-1
         # LIBDIR=/opt/xyce/xyce_lib
@@ -78,8 +80,7 @@ Python 3.7, this script will nonetheless run and attempt to install every compat
         #         yum install -y devtoolset-7
         #         scl enable devtoolset-7 bash
         # fi
-        # cd ./docker/conda/scripts/Xyce
-        # git pull --rebase
+        # git pull
         # ./bootstrap
         # ./configure CXXFLAGS="-O3 -std=c++11" ARCHDIR=$LIBDIR --prefix=$INSTALLDIR CPPFLAGS="-I/usr/include/suitesparse"
         # make

--- a/dependencies.sh
+++ b/dependencies.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
-
+# CHANGES: 
+# 1) User-friendly comments added to beginning of script. 
+# 2) Potential architecture compatibility issues made known.  
 
 if which python3 >> /dev/null
 then

--- a/dependencies.sh
+++ b/dependencies.sh
@@ -1,7 +1,29 @@
-#!/bin/bash
-# CHANGES: 
-# 1) User-friendly comments added to beginning of script. 
-# 2) Potential architecture compatibility issues made known.  
+#!/bin/bash 
+
+printf "Function: \nIf this script runs smoothly, all necessary dependencies for 
+OpenFASoC will be downloaded at once.\n
+Basic Requirements (not exhaustive): 
+(1) Python 3.7 or higher is required.
+(2) Intel x86 architecture is required, as this script will use Conda to download several
+Python packages for which versions compatible with ARM architecture currently do not
+exist for installation in Conda's package repository. If your machine does not run 
+on Intel x86 architecture, this script will likely not work.
+(3) CentOS and Ubuntu are the only operating systems this script has been verified to work on.
+Other Linux distributions will probably work. We cannot guarantee successful compilation on
+Windows and on MacOS.\n\n"
+
+proceed_confirmed=false
+while ! $proceed_confirmed
+do
+        read -p "Do you wish to proceed with the installation? [y\n]: " selection
+        if [ "$selection" == "y" ] || [ "$selection" == "Y" ]; then 
+        echo "Beginning installation..."; proceed_confirmed=true
+        elif [ "$selection" == "n" ] || [ "$selection" == "N" ]; then
+        echo "Quitting script."; exit
+        else
+        echo "Invalid selection. Choose y or n."
+        fi
+done
 
 if which python3 >> /dev/null
 then

--- a/docker/conda/scripts/xyce_install_rhel.sh
+++ b/docker/conda/scripts/xyce_install_rhel.sh
@@ -1,0 +1,107 @@
+# https://github.com/Xyce/Xyce/discussions/4#discussioncomment-169255
+
+###########################################################################
+# References:
+#
+# https://xyce.sandia.gov/documentation/BuildingGuide.html
+# https://github.com/Xyce/Xyce
+#
+###########################################################################
+
+###########################################################################
+#Install Dependancies
+###########################################################################
+
+yum install wget git make gcc-c++ python3 -y
+yum install gcc-gfortran bison flex libtool-ltdl-devel -y
+yum install fftw-devel suitesparse-devel blas-devel lapack-devel -y
+yum install openmpi-devel openmpi -y
+yum install cmake
+yum install lapack-devel
+yum install lapack
+yum install bison
+yum install flex
+yum install fftw-devel
+yum install suitesparse-devel
+yum install suitesparse
+yum install autoconf
+yum install automake
+yum install libtool
+yum install openmpi
+yum install openmpi-devel
+
+# gcc v7 necessary for successful build of Xyce
+yum install -y centos-release-scl
+yum install -y devtoolset-7
+scl enable devtoolset-7 bash
+
+###########################################################################
+#Install Trilinos from source
+###########################################################################
+
+wget https://github.com/trilinos/Trilinos/archive/trilinos-release-12-12-1.tar.gz 
+tar zxvf trilinos-release-12-12-1.tar.gz
+
+SRCDIR=$PWD/Trilinos-trilinos-release-12-12-1
+LIBDIR=/opt/xyce/xyce_lib
+INSTALLDIR=/opt/xyce/xyce_serial
+FLAGS="-O3 -fPIC"
+
+cmake \
+-G "Unix Makefiles" \
+-DCMAKE_C_COMPILER=gcc \
+-DCMAKE_CXX_COMPILER=g++ \
+-DCMAKE_Fortran_COMPILER=gfortran \
+-DCMAKE_CXX_FLAGS="$FLAGS" \
+-DCMAKE_C_FLAGS="$FLAGS" \
+-DCMAKE_Fortran_FLAGS="$FLAGS" \
+-DCMAKE_INSTALL_PREFIX=$LIBDIR \
+-DCMAKE_MAKE_PROGRAM="make" \
+-DTrilinos_ENABLE_NOX=ON \
+-DNOX_ENABLE_LOCA=ON \
+-DTrilinos_ENABLE_EpetraExt=ON \
+-DEpetraExt_BUILD_BTF=ON \
+-DEpetraExt_BUILD_EXPERIMENTAL=ON \
+-DEpetraExt_BUILD_GRAPH_REORDERINGS=ON \
+-DTrilinos_ENABLE_TrilinosCouplings=ON \
+-DTrilinos_ENABLE_Ifpack=ON \
+-DTrilinos_ENABLE_Isorropia=ON \
+-DTrilinos_ENABLE_AztecOO=ON \
+-DTrilinos_ENABLE_Belos=ON \
+-DTrilinos_ENABLE_Teuchos=ON \
+-DTeuchos_ENABLE_COMPLEX=ON \
+-DTrilinos_ENABLE_Amesos=ON \
+-DAmesos_ENABLE_KLU=ON \
+-DTrilinos_ENABLE_Sacado=ON \
+-DTrilinos_ENABLE_Kokkos=OFF \
+-DTrilinos_ENABLE_ALL_OPTIONAL_PACKAGES=OFF \
+-DTrilinos_ENABLE_CXX11=ON \
+-DTPL_ENABLE_AMD=ON \
+-DAMD_LIBRARY_DIRS="/usr/lib" \
+-DTPL_AMD_INCLUDE_DIRS="/usr/include/suitesparse" \
+-DTPL_ENABLE_BLAS=ON \
+-DTPL_ENABLE_LAPACK=ON \
+$SRCDIR
+
+make
+
+mkdir -p $LIBDIR
+make install
+
+###########################################################################
+#Install Xyce from Source
+###########################################################################
+
+#Clone Xyce
+git clone https://github.com/Xyce/Xyce.git
+
+#Build Xyce
+cd Xyce
+./bootstrap
+./configure CXXFLAGS="-O3 -std=c++11" ARCHDIR=$LIBDIR --prefix=$INSTALLDIR CPPFLAGS="-I/usr/include/suitesparse"
+make
+mkdir -p $INSTALLDIR
+make install
+
+#Test installation
+$INSTALLDIR/bin/Xyce


### PR DESCRIPTION
Changes made:

- Corner cases addressed: dependencies.sh now supports CentOS (the script previously could not download Ngspice, Xyce, and Klayout on CentOS). A helper file, named xyce_install_rhel.sh, was added to facilitate Xyce installation. 

- Once dependencies.sh has been used to successfully install all dependencies, it can be run again with the option to partially update the installed dependencies. Script will update conda itself and all installed conda package dependencies. One caveat is that the latest version of Conda right now requires Python 3.8, meaning that not all conda packages will be updated if the user does not have Python greater than 3.8. If the user has 3.7, the script will nonetheless update what it can. Another caveat is Ngspice and Xyce. Because the installation process in the first place requires Ngspice and Xyce to be cloned as Git repos, updating Ngspice and Xyce would require these local repos to be updated to match their respective remote repos. That would require a pull. Because of the inherent unpredictability of including a "git pull" (or anything similar, which could fail or overwrite preexisting user data in a dangerous way) in the script, I've chosen to omit this feature for now. 

- dependencies.sh made slightly more user-friendly by having it announce basic information and installation prerequisites before starting installation. Also, when launching the script, users will be prompted to select what they want to do with the script: download dependencies for the first time, update dependencies, or exit script. 

- A makefile named dependencies.mk has been added. File includes targets install and update. User can use makefile to install or update dependencies, if they prefer a makefile to a shell script.