### PR TITLE
Fix temp-sense-gen flow

### DIFF
--- a/openfasoc/generators/temp-sense-gen/flow/scripts/save_images.tcl
+++ b/openfasoc/generators/temp-sense-gen/flow/scripts/save_images.tcl
@@ -20,7 +20,8 @@ gui::set_display_controls "Instances/StdCells/*" visible true
 gui::set_display_controls "Instances/Macro" visible true
 gui::set_display_controls "Instances/Pads/*" visible true
 gui::set_display_controls "Instances/Physical/*" visible true
-gui::set_display_controls "Pins" visible true
+gui::set_display_controls "Shape Types/Pins" visible true
+gui::set_display_controls "Shape Types/*/*" visible true
 gui::set_display_controls "Misc/Instances/names" visible true
 gui::set_display_controls "Misc/Scale bar" visible true
 gui::set_display_controls "Misc/Highlight selected" visible true


### PR DESCRIPTION
Updates the Pin instantiation control in gui's `set_display_control` statements. Synchronises this section with the upstream ORFS `save_images.tcl` file