### PR TITLE
fix issue with pip install glayout with git+ command

### DIFF
--- a/openfasoc/generators/glayout/setup.py
+++ b/openfasoc/generators/glayout/setup.py
@@ -29,7 +29,7 @@ setup(
         "chromadb",
         "ollama",
         "unstructured",
-        "unstructured[md]"
+        "unstructured[md]",
         "sentence-transformers",
         "peft",
         "accelerate",


### PR DESCRIPTION
```
× python setup.py egg_info did not run successfully.
  │ exit code: 1
  ╰─> [3 lines of output]
      error in glayout setup command: 'install_requires' must be a string or list of strings containing valid project/version requirement specifiers; Expected end or semicolon (after name and no valid version specifier)
          unstructured[md]sentence-transformers
```

fixes this issue, when running

```
pip install git+https://github.com/idea-fasoc/OpenFASOC.git@main#subdirectory=openfasoc/generators/glayout
```