### PR TITLE
Update Dockerfile to remove Yosys from build

### DIFF
--- a/docker/conda/Dockerfile
+++ b/docker/conda/Dockerfile
@@ -11,8 +11,7 @@ RUN wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh \
     && rm ./Miniconda3-latest-Linux-x86_64.sh
 ENV PATH=/usr/bin/miniconda3/bin:${PATH}
 RUN conda update conda --all -y
-RUN conda install python=3.10 \
-                   yosys \
+RUN conda install python=3.11 \
                    open_pdks.sky130a \
                    open_pdks.gf180mcuC \
                    magic \
@@ -26,7 +25,8 @@ ENV PDK_ROOT=/usr/bin/miniconda3/share/pdk/
 
 RUN wget https://www.klayout.org/downloads/Ubuntu-22/klayout_0.28.17-1_amd64.deb
 RUN dpkg -i klayout_0.28.17-1_amd64.deb
-RUN pip install glayout
+RUN pip install layout
+RUN pip install --force-reinstall numpy==1.24
 #RUN strip --remove-section=.note.ABI-tag /usr/lib/x86_64-linux-gnu/libQt5Core.so.5
 
 COPY ./scripts /scripts

--- a/docker/conda/Dockerfile
+++ b/docker/conda/Dockerfile
@@ -25,7 +25,7 @@ ENV PDK_ROOT=/usr/bin/miniconda3/share/pdk/
 
 RUN wget https://www.klayout.org/downloads/Ubuntu-22/klayout_0.28.17-1_amd64.deb
 RUN dpkg -i klayout_0.28.17-1_amd64.deb
-RUN pip install layout
+RUN pip install glayout==0.0.9
 RUN pip install --force-reinstall numpy==1.24
 #RUN strip --remove-section=.note.ABI-tag /usr/lib/x86_64-linux-gnu/libQt5Core.so.5
 


### PR DESCRIPTION
Solves #372 

The Yosus installation breaks the build process due to a parameter mismatch. The numpy version is backdated to ensure Glayout runs properly. 